### PR TITLE
CLOUDP-130486 fix operator crash due to empty modes array

### DIFF
--- a/controllers/validation/validation.go
+++ b/controllers/validation/validation.go
@@ -105,6 +105,10 @@ func validateArbiterSpec(mdb mdbv1.MongoDBCommunity) error {
 func validateAuthModeSpec(mdb mdbv1.MongoDBCommunity) error {
 	allModes := mdb.Spec.Security.Authentication.Modes
 
+	if len(allModes) == 0 {
+		return fmt.Errorf("modes list is empty.")
+	}
+
 	// Check that no auth is defined more than once
 	mapModes := make(map[mdbv1.AuthMode]struct{})
 	for i, mode := range allModes {


### PR DESCRIPTION
### What problem does this PR solve?
This PR closes closes #1055.

When `spec.security.modes` field is set to an empty array, the operator crashes. Upon inspection of the operator error log, we find that the crash happens when the operator is `Validating MongoDB.Spec` as it results in a index out of range [0] with length 0 runtime error. 

```go
func (m MongoDBCommunity) GetScramOptions() scram.Options {

	ignoreUnknownUsers := true
	if m.Spec.Security.Authentication.IgnoreUnknownUsers != nil {
		ignoreUnknownUsers = *m.Spec.Security.Authentication.IgnoreUnknownUsers
	}

	authModes := m.Spec.Security.Authentication.Modes
	defaultAuthMechanism := ConvertAuthModeToAuthMechanism(defaultMode)
	autoAuthMechanism := ConvertAuthModeToAuthMechanism(authModes[0])

	authMechanisms := make([]string, len(authModes))

	for i, authMode := range authModes {
		if authMech := ConvertAuthModeToAuthMechanism(authMode); authMech != "" {
			authMechanisms[i] = authMech
			if authMech == defaultAuthMechanism {
				autoAuthMechanism = defaultAuthMechanism
			}
		}
	}

	return scram.Options{
		AuthoritativeSet:   !ignoreUnknownUsers,
		KeyFile:            scram.AutomationAgentKeyFilePathInContainer,
		AutoAuthMechanisms: authMechanisms,
		AgentName:          scram.AgentName,
		AutoAuthMechanism:  autoAuthMechanism,
	}
}
```

It seems that when setting the `autoAuthMechanism` the operator tries to assign the first authentication mode at the 0th index of the Modes array. Since the array is empty, the index is out of range.

### What changes were made?

During validation of the `authModeSpec`, in addition to checking for duplicates, we can include an additional check as part of `validateAuthModeSpec` in controllers/validation/validation.go:

```go
func validateAuthModeSpec(mdb mdbv1.MongoDBCommunity) error {
	allModes := mdb.Spec.Security.Authentication.Modes

	// Check that no auth is defined more than once
	mapModes := make(map[mdbv1.AuthMode]struct{})
	for i, mode := range allModes {
		if value := mdbv1.ConvertAuthModeToAuthMechanism(mode); value == "" {
			return fmt.Errorf("unexpected value (%q) defined for supported authentication modes", value)
		}
		mapModes[allModes[i]] = struct{}{}
	}
	if len(mapModes) != len(allModes) {
		return fmt.Errorf("some authentication modes are declared twice or more")
	}

	return nil
}
```

```go
if len(allModes) == 0 {
	return fmt.Errorf("modes list is empty.")
}
```

### Code changes

- [x] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [ ] No code <!-- If this PR contains no code changes, check this box -->

This is a simple fix and we suppose no test above is needed.

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [ ] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### All Submissions:

* [x] Have you opened an Issue before filing this PR?
* [x] Have you signed our [CLA](https://www.mongodb.com/legal/contributor-agreement)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
